### PR TITLE
Expand and modernize documentation

### DIFF
--- a/lib/logstash/outputs/exec.rb
+++ b/lib/logstash/outputs/exec.rb
@@ -2,25 +2,36 @@
 require "logstash/namespace"
 require "logstash/outputs/base"
 
-# This output will run a command for any matching event.
-# Example:
+# The exec output will run a command for each event received. Ruby's
+# `system()` function will be used, i.e. the command string will
+# be passed to a shell. You can use `%{name}` and other dynamic strings
+# in the command to pass select fields from the event to the child
+# process. Example:
 # [source,ruby]
 #     output {
-#       exec {
-#         type => abuse
-#         command => "iptables -A INPUT -s %{clientip} -j DROP"
+#       if [type] == "abuse" {
+#         exec {
+#           command => "iptables -A INPUT -s %{clientip} -j DROP"
+#         }
 #       }
 #     }
 #
-# Run subprocesses via system ruby function
+# WARNING: If you want it non-blocking you should use `&` or `dtach`
+# or other such techniques. There is no timeout for the commands being
+# run so misbehaving commands could otherwise stall the Logstash
+# pipeline indefinitely.
 #
-# WARNING: if you want it non-blocking you should use & or dtach or other such
-# techniques
+# WARNING: Exercise great caution with `%{name}` field placeholders.
+# The contents of the field will be included verbatim without any
+# sanitization, i.e. any shell metacharacters from the field values
+# will be passed straight to the shell.
 class LogStash::Outputs::Exec < LogStash::Outputs::Base
 
   config_name "exec"
 
-  # Command line to execute via subprocess. Use dtach or screen to make it non blocking
+  # Command line to execute via subprocess. Use `dtach` or `screen` to
+  # make it non blocking. This value can include `%{name}` and other
+  # dynamic strings.
   config :command, :validate => :string, :required => true
 
   public


### PR DESCRIPTION
Replace old-fashioned "type => foo" conditional with an "if" conditional block in the example and generally expand the documentation to decrease the need for reading the source code to understand what the plugin does.
