### PR TITLE
Refactor `Kernel.system` for `popen3` and allow better debugging tool to the user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,21 @@
+## 3.0.2
+ - Replace `Kernel.system` with `Open3.open3` and fixes `ThreadDeath` issues
+ - Will now log stdout and stderr of the command when running logstash in debug mode, the response is streamed to the log.
+ - Added a `quiet` option to not print the result of the command to stdout, this option is on by default for backward compatibility
+ - Added tests
+
 ## 3.0.1
   - Republish all the gems under jruby.
+
 ## 3.0.0
   - Update the plugin to the version 2.0 of the plugin api, this change is required for Logstash 5.0 compatibility. See https://github.com/elastic/logstash/issues/5141
-# 2.0.4
+
+## 2.0.4
   - Depend on logstash-core-plugin-api instead of logstash-core, removing the need to mass update plugins on major releases of logstash
-# 2.0.3
+
+## 2.0.3
   - New dependency requirements for logstash-core for the 5.0 release
+
 ## 2.0.0
  - Plugins were updated to follow the new shutdown semantic, this mainly allows Logstash to instruct input plugins to terminate gracefully, 
    instead of using Thread.raise on the plugins' threads. Ref: https://github.com/elastic/logstash/pull/3895

--- a/logstash-output-exec.gemspec
+++ b/logstash-output-exec.gemspec
@@ -1,7 +1,6 @@
 Gem::Specification.new do |s|
-
   s.name            = 'logstash-output-exec'
-  s.version         = '3.0.1'
+  s.version         = '3.0.2'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This output will run a command for any matching event."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"
@@ -23,5 +22,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "logstash-core-plugin-api", "~> 2.0"
 
   s.add_development_dependency 'logstash-devutils'
+  s.add_development_dependency "logstash-codec-plain"
 end
 

--- a/spec/outputs/exec_spec.rb
+++ b/spec/outputs/exec_spec.rb
@@ -1,1 +1,48 @@
+# encoding: utf-8
+require "logstash/outputs/exec"
+require "logstash/event"
 require "logstash/devutils/rspec/spec_helper"
+require "tempfile"
+
+describe LogStash::Outputs::Exec do
+  let(:event) { LogStash::Event.new({ "params" => "1234" }) }
+  let(:output) { "1" }
+  let(:command) { "echo #{output}" }
+
+  let(:config) do
+    { "command" => command }
+  end
+
+  let(:error_message) { "Oulala" }
+  let(:stderr) { Tempfile.new(error_message) }
+  let(:stdout) { Tempfile.new(output) }
+  let(:stdin) { Tempfile.new("") }
+
+  subject { described_class.new(config) }
+
+  it "receive a command and execute it" do
+    expect(Open3).to receive(:popen3).with(command)
+    subject.receive(event)
+  end
+
+  context "when debugging" do
+    before :each do
+      allow(subject.logger).to receive(:debug?).and_return(true)
+      expect(Open3).to receive(:popen3).with(command).and_yield(stdin, stdout, stderr)
+    end
+
+    it "register the stdout and stderr to the logger" do
+      expect(subject.logger).to receive(:pipe).with(stdout => :debug, stderr => :debug)
+      subject.receive(event)
+    end
+  end
+
+  context "When debugging is off" do
+    context "when quiet is off" do
+      it "write output to the terminal" do
+        expect(subject.logger).to receive(:terminal).with(output)
+        subject.receive(event)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR include the following refactor:
- Move from `Kernel.stop` to `Open3.popen3`
- When logstash is running in debug mode the stdout and the stderr of
  the plugin will be streamed to the log.
- Added an option to run the command in `quiet` mode so the result of
  the command is not directly print to stdout.
- Added tests

Fixes: #4
