### PR TITLE
Make this compatible with LS 5.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 3.1.0
+  - Log output of the exec'd command using log4j info and debug
+
 ## 3.0.3
   - Relax constraint on logstash-core-plugin-api to >= 1.60 <= 2.99
 

--- a/lib/logstash/outputs/exec.rb
+++ b/lib/logstash/outputs/exec.rb
@@ -50,7 +50,7 @@ class LogStash::Outputs::Exec < LogStash::Outputs::Base
 
     Open3.popen3(cmd) do |stdin, stdout, stderr|
       if @logger.debug?
-        @logger.debug(stdout => :debug, stderr => :debug)
+        @logger.debug(:stdout => stdout.read.chomp, :stderr => stderr.read.chomp)
       else
         # This is for backward compatibility,
         # the previous implementation was using `Kernel#system' and the default behavior

--- a/lib/logstash/outputs/exec.rb
+++ b/lib/logstash/outputs/exec.rb
@@ -50,12 +50,12 @@ class LogStash::Outputs::Exec < LogStash::Outputs::Base
 
     Open3.popen3(cmd) do |stdin, stdout, stderr|
       if @logger.debug?
-        @logger.pipe(stdout => :debug, stderr => :debug)
+        @logger.debug(stdout => :debug, stderr => :debug)
       else
         # This is for backward compatibility,
         # the previous implementation was using `Kernel#system' and the default behavior
         # of this method is to output the result to the terminal.
-        @logger.terminal(stdout.read.chomp) unless quiet?
+        @logger.info(stdout.read.chomp) unless quiet?
       end
     end
   end

--- a/lib/logstash/outputs/exec.rb
+++ b/lib/logstash/outputs/exec.rb
@@ -50,7 +50,7 @@ class LogStash::Outputs::Exec < LogStash::Outputs::Base
 
     Open3.popen3(cmd) do |stdin, stdout, stderr|
       if @logger.debug?
-        @logger.debug(:stdout => stdout.read.chomp, :stderr => stderr.read.chomp)
+        @logger.debug("debugging command", :stdout => stdout.read.chomp, :stderr => stderr.read.chomp)
       else
         # This is for backward compatibility,
         # the previous implementation was using `Kernel#system' and the default behavior

--- a/logstash-output-exec.gemspec
+++ b/logstash-output-exec.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name            = 'logstash-output-exec'
-  s.version         = '3.0.3'
+  s.version         = '3.1.0'
   s.licenses        = ['Apache License (2.0)']
   s.summary         = "This output will run a command for any matching event."
   s.description     = "This gem is a Logstash plugin required to be installed on top of the Logstash core pipeline using $LS_HOME/bin/logstash-plugin install gemname. This gem is not a stand-alone program"

--- a/spec/outputs/exec_spec.rb
+++ b/spec/outputs/exec_spec.rb
@@ -32,7 +32,8 @@ describe LogStash::Outputs::Exec do
     end
 
     it "register the stdout and stderr to the logger" do
-      expect(subject.logger).to receive(:pipe).with(stdout => :debug, stderr => :debug)
+      expect(subject.logger).to receive(:debug).with(/running exec command/, hash_including(:command))
+      expect(subject.logger).to receive(:debug).with(/debugging/, hash_including(:stdout, :stderr))
       subject.receive(event)
     end
   end
@@ -40,7 +41,7 @@ describe LogStash::Outputs::Exec do
   context "When debugging is off" do
     context "when quiet is off" do
       it "write output to the terminal" do
-        expect(subject.logger).to receive(:terminal).with(output)
+        expect(subject.logger).to receive(:info).with(output)
         subject.receive(event)
       end
     end


### PR DESCRIPTION
Logging changes in 5.0 broke this plugin. We now use info and debug
to log output of the exec'd commands

Fixes #10