### PR TITLE
Specs: Require logstash-core to drag in Log4j jar

### DIFF
--- a/spec/outputs/exec_spec.rb
+++ b/spec/outputs/exec_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+require "logstash-core"
 require "logstash/outputs/exec"
 require "logstash/event"
 require "logstash/devutils/rspec/spec_helper"


### PR DESCRIPTION
Without this the specs fail with the following error:

    NameError:
      missing class name (`org.apache.logging.log4j.Level')

The logstash-core module makes sure the Log4j jar (and various other jars) is loaded. When this plugin is loaded by Logstash itself that module is obviously already loaded but that's not the case when just running the specs.

Fixes #14